### PR TITLE
Permitir configuração de pontos iniciais e limites de aprimoramentos

### DIFF
--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -28,6 +28,7 @@
     "Aprimoramentos.PointsTitle": "Pontos de Aprimoramento",
     "Aprimoramentos.Vantagens": "Positivos",
     "Aprimoramentos.Desvantagens": "Negativos",
+    "Aprimoramentos.NegativeLimit": "Limite de Negativos",
     "Pericias.DescriptionManual": "Distribua os pontos de perícia para definir as habilidades do seu personagem. A perícia 'Briga' é automática. Adicione outras perícias manualmente, lembrando que o gasto mínimo em uma nova perícia é 10 pontos.",
     "Pericias.PointsTitle": "Pontos de Perícia",
     "PericiasCombate.Description": "Use seus pontos de perícia para aprimorar suas capacidades de combate. Lembre-se que cada perícia de combate tem valores de ataque e defesa separados.",
@@ -49,6 +50,14 @@
     "Extras.Label": "Poderes e Habilidades Especiais",
     "Nav.Next": "Próximo",
     "Nav.Prev": "Anterior",
-    "Nav.Finish": "Concluir Personagem"
+    "Nav.Finish": "Concluir Personagem",
+    "Settings": {
+      "AttributePoints": "Pontos iniciais de atributos",
+      "AttributePointsHint": "Total de pontos para distribuir nos atributos.",
+      "PositiveEnhancements": "Pontos de aprimoramentos positivos",
+      "PositiveEnhancementsHint": "Total de pontos disponíveis para aprimoramentos positivos.",
+      "NegativeEnhancements": "Limite de aprimoramentos negativos",
+      "NegativeEnhancementsHint": "Quantidade máxima de pontos que podem ser ganhos com aprimoramentos negativos."
+    }
   }
 }

--- a/templates/step-1-campaign.hbs
+++ b/templates/step-1-campaign.hbs
@@ -21,8 +21,9 @@
             <hr>
             <h4>Pontos Iniciais:</h4>
             <ul>
-                <li><strong>Atributos:</strong> {{selectedScenario.points.attributes}} pontos</li>
-                <li><strong>Aprimoramentos:</strong> {{selectedScenario.points.aprimoramentos}} pontos</li>
+                <li><strong>{{localize "DAEMON_WIZARD.Steps.Attributes"}}:</strong> {{configPoints.attributes}} pontos</li>
+                <li><strong>{{localize "DAEMON_WIZARD.Aprimoramentos.Vantagens"}}:</strong> {{configPoints.aprimoramentosPositivos}} pontos</li>
+                <li><strong>{{localize "DAEMON_WIZARD.Aprimoramentos.Desvantagens"}}:</strong> {{configPoints.aprimoramentosNegativos}} pontos</li>
             </ul>
         {{else}}
             <p><i>Selecione uma campanha para ver os detalhes.</i></p>

--- a/templates/step-4-aprimoramentos.hbs
+++ b/templates/step-4-aprimoramentos.hbs
@@ -6,10 +6,14 @@
 
     <div class="points-tracker">
         <h3>{{localize "DAEMON_WIZARD.Aprimoramentos.PointsTitle"}}</h3>
-        <div class="points-display {{#if (lt aprimoramentoPoints.remaining 0)}}overspent{{/if}}">
-            <span>{{aprimoramentoPoints.remaining}}</span>
+        <div class="points-display {{#if (lt aprimoramentoPoints.remainingPos 0)}}overspent{{/if}}">
+            <span>{{aprimoramentoPoints.remainingPos}}</span>
         </div>
-        <small>Base: {{aprimoramentoPoints.base}} + Negativos: {{aprimoramentoPoints.fromNegatives}}</small>
+        <small>{{localize "DAEMON_WIZARD.Aprimoramentos.Vantagens"}}: {{aprimoramentoPoints.basePos}} + {{localize "DAEMON_WIZARD.Aprimoramentos.Desvantagens"}}: {{aprimoramentoPoints.gainedFromNeg}}</small>
+        <div class="points-display {{#if (lt aprimoramentoPoints.remainingNeg 0)}}overspent{{/if}}">
+            <span>{{aprimoramentoPoints.remainingNeg}}</span>
+        </div>
+        <small>{{localize "DAEMON_WIZARD.Aprimoramentos.NegativeLimit"}}: {{aprimoramentoPoints.baseNeg}}</small>
     </div>
 
     <div class="aprimoramentos-container">


### PR DESCRIPTION
## Resumo
- Adiciona configurações de sistema para definir pontos iniciais de atributos, aprimoramentos positivos e negativos
- Ajusta cálculos do assistente para usar esses valores com contadores separados
- Atualiza templates e traduções para exibir os novos controles e limites

## Testes
- `npm test` *(falhou: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689196789b8c83219aa07dda91db0e73